### PR TITLE
Add github bannner

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,11 @@
   </div>
 
   <div style="clear: both;"></div>
+  
+  <a href="https://github.com/chriscoyier/HTML-Ipsum">
+    <img src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67"
+         style="position: absolute; top: 0; right: 0; border: 0;" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" >
+  </a>
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
   <script src="js/ZeroClipboard.js"></script>


### PR DESCRIPTION
I didn't realize at first that the code for this site was public on github. This change adds a link back to the repo from the site, matching the function of link from the repo to the site that is already present in the README.
